### PR TITLE
Problem: uptime is not updated when device is on battery

### DIFF
--- a/src/fty_kpi_power_uptime.c
+++ b/src/fty_kpi_power_uptime.c
@@ -65,7 +65,7 @@ int main (int argc, char *argv [])
     zsock_wait (server);
     zstr_sendx (server, "CONNECT", endpoint, NULL);
     zsock_wait (server);
-    zstr_sendx (server, "CONSUMER", "METRICS", "status.ups.*", NULL);
+    zstr_sendx (server, "CONSUMER", "METRICS", "^(status.ups|status)@.*", NULL);
     zsock_wait (server);
 
     //  Accept and print any message back from server


### PR DESCRIPTION
Solution: "uptime" was looking for messages with incorrect subject -> subject corrected
Signed-off-by: Barbora Stepankova <barborastepankova@eaton.com>