### PR TITLE
Problem: debug info is printed too often

### DIFF
--- a/src/dc.c
+++ b/src/dc.c
@@ -97,8 +97,10 @@ dc_set_offline (dc_t *self, char* ups)
 
     void *foo = zlistx_find (self->ups, ups);
     if (!foo)
+    {
         zlistx_add_end (self->ups, ups);
-    zsys_debug ("uptime: ups %s set offline", ups);
+        zsys_debug ("uptime: ups %s set offline", ups);
+    }
 }
 
 void


### PR DESCRIPTION
Solution: print it only when necessary

Signed-off-by: Barbora Stepankova <BarboraStepankova@eaton.com>