### PR TITLE
Problem: Hash assiging DCs to UPSes sometimes gets corrupted.

### DIFF
--- a/src/fty_kpi_power_uptime_server.c
+++ b/src/fty_kpi_power_uptime_server.c
@@ -147,7 +147,8 @@ s_set_dc_upses (fty_kpi_power_uptime_server_t *self, fty_proto_t *fmsg)
         return;
     }
 
-    zhash_t *aux = fty_proto_aux (fmsg);
+    zhash_t *aux = fty_proto_get_aux (fmsg);
+    zhash_autofree (aux);
     if (!aux)
     {
         zsys_error ("s_set_dc_upses: missing aux in fty-proto message");
@@ -186,6 +187,7 @@ s_set_dc_upses (fty_kpi_power_uptime_server_t *self, fty_proto_t *fmsg)
     uint64_t total, offline;
     upt_uptime (self->upt, dc_name, &total, &offline);
     zlistx_destroy (&ups);
+    zhash_destroy (&aux);
 }
 
 static void


### PR DESCRIPTION
Solution: Function s_set_dc_upses gets direct pointer to aux from ASSET message.
Then it creates a list, where it stores direct pointers to UPSes in aux. These pointers
are then duplicated in upt_add, but by that time, original ASSET messsage may have been
already destroyed and therefore, we duplicate garbage.

If I'm right and this is the issue, creating a copy of aux should help.

Signed-off-by: Jana Rapava <janarapava@eaton.com>